### PR TITLE
Get find_unsed_parameters from config

### DIFF
--- a/essmc2/apis/model.py
+++ b/essmc2/apis/model.py
@@ -18,6 +18,7 @@ def get_model(cfg: Config, logger: Optional[logging.Logger] = None):
 
     if cfg.dist.distributed:
         model = DistributedDataParallel(model,
+                                        find_unused_parameters=cfg.dist.get("find_unused_parameters", False),
                                         device_ids=[torch.cuda.current_device()],
                                         output_device=torch.cuda.current_device())
     return model


### PR DESCRIPTION
## What do these changes do?

For some models which contain unused parameters(Wav2Vec2 from huggingface etc.), original code will raise an ERROR for `find_unused_parameters` in DistributedDataParallel is False by default. Make the parameter take correct value from config file to avoid the error.
